### PR TITLE
Corrected discourse anchor text in index.md

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -6,7 +6,7 @@ Juno Community
 
 There are various outlets to talk to other people about Juno, and get help when you need it:
 
-* [discuss.Juno](http://discourse.julialang.org/) – the official community hub for
+* [discourse.JuliaLang](http://discourse.julialang.org/) – the official community hub for
   questions, support and discussion. You'll get help fastest here.
 * [GitHub](https://github.com/JunoLab/) – Source code!
 * [Reddit](http://www.reddit.com/r/juno) – for Juno-related news


### PR DESCRIPTION
Corrected anchor text to match the new link destination and no longer be misleading.